### PR TITLE
Breaking: Update preset-env, stage-3 includes import syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,7 @@ module.exports = function(context, opts) {
       [require('babel-preset-env'), envOpts],
       require('babel-preset-stage-3'),
     ],
-    plugins: [
-      require('babel-plugin-syntax-dynamic-import'),
-    ],
+    plugins: [],
   };
 
   if (env === 'test') {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
   "dependencies": {
     "babel-plugin-istanbul": "^4.0.0",
     "babel-plugin-rewire": "^1.0.0",
-    "babel-plugin-syntax-dynamic-import": "7.0.0-alpha.3",
-    "babel-preset-env": "v2.0.0-alpha.5",
-    "babel-preset-stage-3": "7.0.0-alpha.7"
+    "babel-preset-env": "v2.0.0-alpha.6",
+    "babel-preset-stage-3": "7.0.0-alpha.8"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ describe('babel-preset-behance', function() {
         }],
         require('babel-preset-stage-3'),
       ],
-      plugins: [require('babel-plugin-syntax-dynamic-import')],
+      plugins: [],
     };
     expect(preset()).to.deep.equal(expected);
   });
@@ -35,7 +35,6 @@ describe('babel-preset-behance', function() {
           require('babel-preset-stage-3'),
         ],
         plugins: [
-          require('babel-plugin-syntax-dynamic-import'),
           require('babel-plugin-rewire'),
         ],
       };
@@ -57,7 +56,6 @@ describe('babel-preset-behance', function() {
           require('babel-preset-stage-3'),
         ],
         plugins: [
-          require('babel-plugin-syntax-dynamic-import'),
           require('babel-plugin-istanbul').default,
           require('babel-plugin-rewire'),
         ],
@@ -80,7 +78,6 @@ describe('babel-preset-behance', function() {
           require('babel-preset-stage-3'),
         ],
         plugins: [
-          require('babel-plugin-syntax-dynamic-import'),
           require('babel-plugin-istanbul').default,
           require('babel-plugin-rewire'),
         ],
@@ -103,7 +100,7 @@ describe('babel-preset-behance', function() {
           }],
           require('babel-preset-stage-3'),
         ],
-        plugins: [require('babel-plugin-syntax-dynamic-import')],
+        plugins: [],
       };
       expect(preset()).to.deep.equal(expected);
     });
@@ -123,7 +120,7 @@ describe('babel-preset-behance', function() {
           }],
           require('babel-preset-stage-3'),
         ],
-        plugins: [require('babel-plugin-syntax-dynamic-import')],
+        plugins: [],
       };
       expect(preset(null, { env: {} })).to.deep.equal(expected);
     });
@@ -152,7 +149,7 @@ describe('babel-preset-behance', function() {
           }],
           require('babel-preset-stage-3'),
         ],
-        plugins: [require('babel-plugin-syntax-dynamic-import')],
+        plugins: [],
       };
       expect(preset(null, { env: envOpts })).to.deep.equal(expected);
     });
@@ -182,7 +179,7 @@ describe('babel-preset-behance', function() {
           }],
           require('babel-preset-stage-3'),
         ],
-        plugins: [require('babel-plugin-syntax-dynamic-import')],
+        plugins: [],
       };
       expect(preset(null, { env: envOpts })).to.deep.equal(expected);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,43 +106,43 @@ babel-generator@^6.18.0:
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-babel-helper-builder-binary-assignment-operator-visitor@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-7.0.0-alpha.7.tgz#5c909122947ac486f1d3a84836327e9cd9553980"
+babel-helper-builder-binary-assignment-operator-visitor@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-7.0.0-alpha.8.tgz#38daf02a4854f62ca3cc3accc731faa24dc018dd"
   dependencies:
-    babel-helper-explode-assignable-expression "7.0.0-alpha.7"
+    babel-helper-explode-assignable-expression "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-helper-call-delegate@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-7.0.0-alpha.7.tgz#694f10551d74fc582394b5372f5386d67bfe0349"
+babel-helper-call-delegate@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-7.0.0-alpha.8.tgz#1fd7ec16f331d0d49af227a4f6f91381d4b6ab23"
   dependencies:
     babel-helper-hoist-variables "7.0.0-alpha.7"
-    babel-traverse "7.0.0-alpha.7"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-helper-define-map@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-7.0.0-alpha.7.tgz#92971c4cc24426dffe8946fd83a4b994e7e672dd"
+babel-helper-define-map@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-helper-define-map/-/babel-helper-define-map-7.0.0-alpha.8.tgz#a2d1e7a08a6a0b803441d70256e193d0a6b466a2"
   dependencies:
-    babel-helper-function-name "7.0.0-alpha.7"
+    babel-helper-function-name "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
     lodash "^4.2.0"
 
-babel-helper-explode-assignable-expression@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-7.0.0-alpha.7.tgz#114b676437f4cb694eeb51afcd4cc9b0bf926c5c"
+babel-helper-explode-assignable-expression@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-7.0.0-alpha.8.tgz#ee2e88e0c44fd68961a8df197ccedc39f6e0df3a"
   dependencies:
-    babel-traverse "7.0.0-alpha.7"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-helper-function-name@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.7.tgz#19aecddc5402f941c5726802993077b41ea9832d"
+babel-helper-function-name@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-7.0.0-alpha.8.tgz#b28e20f4c356713b7cf5ef5bc7b28ee2588c8fb1"
   dependencies:
     babel-helper-get-function-arity "7.0.0-alpha.7"
-    babel-template "7.0.0-alpha.7"
-    babel-traverse "7.0.0-alpha.7"
+    babel-template "7.0.0-alpha.8"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
 babel-helper-get-function-arity@7.0.0-alpha.7:
@@ -170,28 +170,28 @@ babel-helper-regex@7.0.0-alpha.7:
     babel-types "7.0.0-alpha.7"
     lodash "^4.2.0"
 
-babel-helper-remap-async-to-generator@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-7.0.0-alpha.7.tgz#c1436c4cb0d8c01f65f0a055098a05df24d53c7c"
+babel-helper-remap-async-to-generator@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-7.0.0-alpha.8.tgz#329424026a321be871c02e96b1baea85b906c399"
   dependencies:
-    babel-helper-function-name "7.0.0-alpha.7"
-    babel-template "7.0.0-alpha.7"
-    babel-traverse "7.0.0-alpha.7"
+    babel-helper-function-name "7.0.0-alpha.8"
+    babel-template "7.0.0-alpha.8"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-helper-replace-supers@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-7.0.0-alpha.7.tgz#73ceb5bfeb597ff2c2772a75f0aa013be58e78fe"
+babel-helper-replace-supers@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-7.0.0-alpha.8.tgz#f7354ace21088676a2c378c68671095b04d53e78"
   dependencies:
     babel-helper-optimise-call-expression "7.0.0-alpha.7"
-    babel-messages "7.0.0-alpha.3"
-    babel-template "7.0.0-alpha.7"
-    babel-traverse "7.0.0-alpha.7"
+    babel-messages "7.0.0-alpha.8"
+    babel-template "7.0.0-alpha.8"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-messages@7.0.0-alpha.3:
-  version "7.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-7.0.0-alpha.3.tgz#c8390a468478b8384da134612e12a6bc31a684e9"
+babel-messages@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-7.0.0-alpha.8.tgz#6fb3eee1e1209491636992a3ed4806e75bbdcdb4"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -199,9 +199,9 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-check-es2015-constants@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-7.0.0-alpha.7.tgz#6089e4f6e8e58b87bb04085beeb4e77103ddee3e"
+babel-plugin-check-es2015-constants@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-7.0.0-alpha.8.tgz#318ad0481c76b5c8c8f85693e8e4f625234f326b"
 
 babel-plugin-istanbul@^4.0.0:
   version "4.1.1"
@@ -235,228 +235,229 @@ babel-plugin-syntax-object-rest-spread@7.0.0-alpha.3:
   version "7.0.0-alpha.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-7.0.0-alpha.3.tgz#52dd2698be335f1c0297d5d34ac526537ef63576"
 
-babel-plugin-syntax-trailing-function-commas@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-alpha.7.tgz#0bb156466bba6c4705dafc98ec7e9f227c704cd3"
+babel-plugin-syntax-trailing-function-commas@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-alpha.8.tgz#63559104587ae4f958550158baf565fee413b02a"
 
-babel-plugin-transform-async-generator-functions@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-7.0.0-alpha.7.tgz#da52dbbc22fd0ebe76ee212cbebfeefe7b6f5612"
+babel-plugin-transform-async-generator-functions@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-7.0.0-alpha.8.tgz#6c656bd22ddbd90ac28d813a613ac54c9511b289"
   dependencies:
-    babel-helper-remap-async-to-generator "7.0.0-alpha.7"
+    babel-helper-remap-async-to-generator "7.0.0-alpha.8"
     babel-plugin-syntax-async-generators "7.0.0-alpha.3"
 
-babel-plugin-transform-async-to-generator@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-7.0.0-alpha.7.tgz#2ccfb70f91d78dc5e3814220d524da2f8df4430c"
+babel-plugin-transform-async-to-generator@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-7.0.0-alpha.8.tgz#12b1dff4caaf6f830a1f95e88772084b498844a3"
   dependencies:
-    babel-helper-remap-async-to-generator "7.0.0-alpha.7"
+    babel-helper-remap-async-to-generator "7.0.0-alpha.8"
     babel-plugin-syntax-async-functions "7.0.0-alpha.3"
 
-babel-plugin-transform-es2015-arrow-functions@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-7.0.0-alpha.7.tgz#5921b86f8ad9391177cb7ec8793bdf2daca1cc4b"
+babel-plugin-transform-es2015-arrow-functions@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-7.0.0-alpha.8.tgz#687c40022147a32fa18b4bd3ffe0b5209f121d41"
 
-babel-plugin-transform-es2015-block-scoped-functions@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-7.0.0-alpha.7.tgz#c3409df41e449c075100c5ff602f98e065577f7a"
+babel-plugin-transform-es2015-block-scoped-functions@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-7.0.0-alpha.8.tgz#7e919e20c49b02e7859cd2b1230f00e13487500d"
 
-babel-plugin-transform-es2015-block-scoping@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-7.0.0-alpha.7.tgz#b82115907057c2edcc379ee0b647f99afc73e36f"
+babel-plugin-transform-es2015-block-scoping@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-7.0.0-alpha.8.tgz#f40b12787629e5bb5fd131b8105c1d19a955d2ae"
   dependencies:
-    babel-template "7.0.0-alpha.7"
-    babel-traverse "7.0.0-alpha.7"
+    babel-template "7.0.0-alpha.8"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
     lodash "^4.2.0"
 
-babel-plugin-transform-es2015-classes@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-7.0.0-alpha.7.tgz#f892baf5e6eec72dbebb3bc4a1466232a414a275"
+babel-plugin-transform-es2015-classes@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-7.0.0-alpha.8.tgz#7e111d6a2b15e674b5778d3ae9df672a62845c27"
   dependencies:
-    babel-helper-define-map "7.0.0-alpha.7"
-    babel-helper-function-name "7.0.0-alpha.7"
+    babel-helper-define-map "7.0.0-alpha.8"
+    babel-helper-function-name "7.0.0-alpha.8"
     babel-helper-optimise-call-expression "7.0.0-alpha.7"
-    babel-helper-replace-supers "7.0.0-alpha.7"
-    babel-messages "7.0.0-alpha.3"
-    babel-template "7.0.0-alpha.7"
-    babel-traverse "7.0.0-alpha.7"
+    babel-helper-replace-supers "7.0.0-alpha.8"
+    babel-messages "7.0.0-alpha.8"
+    babel-template "7.0.0-alpha.8"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-plugin-transform-es2015-computed-properties@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-7.0.0-alpha.7.tgz#88a3eb4a1e817044d35fd916d899f5b22ed7edd6"
+babel-plugin-transform-es2015-computed-properties@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-7.0.0-alpha.8.tgz#03b023f20a9d7670676d8fe04ba9d5c3bdde23e3"
   dependencies:
-    babel-template "7.0.0-alpha.7"
+    babel-template "7.0.0-alpha.8"
 
-babel-plugin-transform-es2015-destructuring@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-7.0.0-alpha.7.tgz#7a5a907cf67f824f6cc5e7832a3f16ba51abdc05"
+babel-plugin-transform-es2015-destructuring@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-7.0.0-alpha.8.tgz#6c7fbed6f8c4ec53adc80f271e04f3cf94b6b8b5"
 
-babel-plugin-transform-es2015-duplicate-keys@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-7.0.0-alpha.7.tgz#6a522462f5123e45de1b6cb1c82cd30bcdea4f91"
+babel-plugin-transform-es2015-duplicate-keys@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-7.0.0-alpha.8.tgz#6504225ef5cc8acbab1812cdc63af5422d2a02be"
   dependencies:
     babel-types "7.0.0-alpha.7"
 
-babel-plugin-transform-es2015-for-of@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-7.0.0-alpha.7.tgz#3dd6e5dc5e98c5044b9cb616252e023b97477ef7"
+babel-plugin-transform-es2015-for-of@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-7.0.0-alpha.8.tgz#6b37fe234bbc52079daad332e85ed4d9cb1a3fc2"
 
-babel-plugin-transform-es2015-function-name@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-7.0.0-alpha.7.tgz#3b6ded23efaf1183de8d234b2bbdec650692924f"
+babel-plugin-transform-es2015-function-name@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-7.0.0-alpha.8.tgz#e48d9585ed33d7653c9b1bff5910bd9f6b391a59"
   dependencies:
-    babel-helper-function-name "7.0.0-alpha.7"
+    babel-helper-function-name "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-plugin-transform-es2015-literals@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-7.0.0-alpha.7.tgz#1c4e552be18f988874caac33c9e9a07e1417d1c6"
+babel-plugin-transform-es2015-literals@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-7.0.0-alpha.8.tgz#c3d78bc9ffe5193afaadf1b21929075b9991f150"
 
-babel-plugin-transform-es2015-modules-amd@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-7.0.0-alpha.7.tgz#29a01b92303036eabe120cfa8af1fd8a23fb41b0"
+babel-plugin-transform-es2015-modules-amd@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-7.0.0-alpha.8.tgz#77451a4c5a4744f55586e5f147756f29b3b4d851"
   dependencies:
-    babel-plugin-transform-es2015-modules-commonjs "7.0.0-alpha.7"
-    babel-template "7.0.0-alpha.7"
+    babel-plugin-transform-es2015-modules-commonjs "7.0.0-alpha.8"
+    babel-template "7.0.0-alpha.8"
 
-babel-plugin-transform-es2015-modules-commonjs@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-7.0.0-alpha.7.tgz#8980ff65ada36f8853950878c80e1ca4d1188e90"
+babel-plugin-transform-es2015-modules-commonjs@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-7.0.0-alpha.8.tgz#e86f997a8c36fb2d2f6641fd20903087929d5e91"
   dependencies:
-    babel-plugin-transform-strict-mode "7.0.0-alpha.7"
-    babel-template "7.0.0-alpha.7"
+    babel-plugin-transform-strict-mode "7.0.0-alpha.8"
+    babel-template "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-plugin-transform-es2015-modules-systemjs@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-7.0.0-alpha.7.tgz#2e2ad4576e433c803e65297b1ca70ca68a432eff"
+babel-plugin-transform-es2015-modules-systemjs@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-7.0.0-alpha.8.tgz#212bf0e3c07231c012d9176bca5fdd68410dd599"
   dependencies:
     babel-helper-hoist-variables "7.0.0-alpha.7"
-    babel-template "7.0.0-alpha.7"
+    babel-template "7.0.0-alpha.8"
 
-babel-plugin-transform-es2015-modules-umd@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-7.0.0-alpha.7.tgz#cd73ec6d2f1d8a3492a5ce440a451b71f9dbacd5"
+babel-plugin-transform-es2015-modules-umd@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-7.0.0-alpha.8.tgz#65e866cda069514d2de19f2ab7360a765e2ed1b3"
   dependencies:
-    babel-plugin-transform-es2015-modules-amd "7.0.0-alpha.7"
-    babel-template "7.0.0-alpha.7"
+    babel-plugin-transform-es2015-modules-amd "7.0.0-alpha.8"
+    babel-template "7.0.0-alpha.8"
 
-babel-plugin-transform-es2015-object-super@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-7.0.0-alpha.7.tgz#0dd56a6bbea14523187c73cede1660280947e91e"
+babel-plugin-transform-es2015-object-super@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-7.0.0-alpha.8.tgz#cffdd0fb416d2fa558e1440b00efe2eabd4232d6"
   dependencies:
-    babel-helper-replace-supers "7.0.0-alpha.7"
+    babel-helper-replace-supers "7.0.0-alpha.8"
 
-babel-plugin-transform-es2015-parameters@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-7.0.0-alpha.7.tgz#9ff005a532110584e4bc1731ee613d1fc8ad69d1"
+babel-plugin-transform-es2015-parameters@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-7.0.0-alpha.8.tgz#12cd45d0caa8a378bd6088bc6e8efd9f0e604631"
   dependencies:
-    babel-helper-call-delegate "7.0.0-alpha.7"
+    babel-helper-call-delegate "7.0.0-alpha.8"
     babel-helper-get-function-arity "7.0.0-alpha.7"
-    babel-template "7.0.0-alpha.7"
-    babel-traverse "7.0.0-alpha.7"
+    babel-template "7.0.0-alpha.8"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
 
-babel-plugin-transform-es2015-shorthand-properties@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-7.0.0-alpha.7.tgz#59678d452808584f62b3b196938673cdca560852"
+babel-plugin-transform-es2015-shorthand-properties@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-7.0.0-alpha.8.tgz#8a5e62d129a92866cb7ced398ba50abe8020c82c"
   dependencies:
     babel-types "7.0.0-alpha.7"
 
-babel-plugin-transform-es2015-spread@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-7.0.0-alpha.7.tgz#6b5a26372b19e2e1d4c63af5e22d298c5c278f5d"
+babel-plugin-transform-es2015-spread@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-7.0.0-alpha.8.tgz#cf4b03d978ce3beb4c770865ef2a1f41ab4f9675"
 
-babel-plugin-transform-es2015-sticky-regex@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-7.0.0-alpha.7.tgz#de71144b924c5c03da720c2982ade2a717b1fded"
+babel-plugin-transform-es2015-sticky-regex@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-7.0.0-alpha.8.tgz#529b7cca63f759ddd7b2af31e421a1160cc0da24"
   dependencies:
     babel-helper-regex "7.0.0-alpha.7"
     babel-types "7.0.0-alpha.7"
 
-babel-plugin-transform-es2015-template-literals@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-7.0.0-alpha.7.tgz#f8deb336f2314eac484d07801594b84c24363984"
+babel-plugin-transform-es2015-template-literals@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-7.0.0-alpha.8.tgz#076273c1e6e92a7a9151d7499d8ef7eeda4b0f7a"
 
-babel-plugin-transform-es2015-typeof-symbol@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-7.0.0-alpha.7.tgz#93af130f02ee1d23c554242a44ba45bd7c2d4fb1"
+babel-plugin-transform-es2015-typeof-symbol@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-7.0.0-alpha.8.tgz#942a1e789cfe2305febdc8074b8f9c3650b844bb"
 
-babel-plugin-transform-es2015-unicode-regex@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-7.0.0-alpha.7.tgz#13b92440afbd0cd088c19ba3becd340627b3eedc"
+babel-plugin-transform-es2015-unicode-regex@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-7.0.0-alpha.8.tgz#9800d48662384fc9a0dbd2fa1fdd18163afecc7d"
   dependencies:
     babel-helper-regex "7.0.0-alpha.7"
     regexpu-core "^4.0.2"
 
-babel-plugin-transform-exponentiation-operator@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-7.0.0-alpha.7.tgz#14d02d8c8d4c3dc7bf3114342c9f5a7185285ad2"
+babel-plugin-transform-exponentiation-operator@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-7.0.0-alpha.8.tgz#a4fd185a83284be4858b72fca675508ae87ea96c"
   dependencies:
-    babel-helper-builder-binary-assignment-operator-visitor "7.0.0-alpha.7"
+    babel-helper-builder-binary-assignment-operator-visitor "7.0.0-alpha.8"
     babel-plugin-syntax-exponentiation-operator "7.0.0-alpha.3"
 
-babel-plugin-transform-object-rest-spread@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-7.0.0-alpha.7.tgz#90f09ea7b9f078fc9e333bbe144aac176eeee970"
+babel-plugin-transform-object-rest-spread@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-7.0.0-alpha.8.tgz#481222175e83e171e6001065468be4b64d6d2d8f"
   dependencies:
     babel-plugin-syntax-object-rest-spread "7.0.0-alpha.3"
 
-babel-plugin-transform-regenerator@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-7.0.0-alpha.7.tgz#2a9ea26acbd7d63a379131667485b64f6ac9d0c2"
+babel-plugin-transform-regenerator@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-7.0.0-alpha.8.tgz#747500fcf167475b3e920b38227e4ee62ba49eb6"
   dependencies:
     regenerator-transform "0.9.11"
 
-babel-plugin-transform-strict-mode@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-7.0.0-alpha.7.tgz#90b2812844e8f2b47d4da4fb98e892fd214e4fe5"
+babel-plugin-transform-strict-mode@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-7.0.0-alpha.8.tgz#de4b3f408f1623d9ab0438d959200adca6ba66ad"
   dependencies:
     babel-types "7.0.0-alpha.7"
 
-babel-preset-env@v2.0.0-alpha.5:
-  version "2.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-2.0.0-alpha.5.tgz#9e82d10cdb1cd51b7ff9ab397082b2d66ab99a1d"
+babel-preset-env@v2.0.0-alpha.6:
+  version "2.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-2.0.0-alpha.6.tgz#d8ddd8d9c6028bdd219e7621a41eef520a04483d"
   dependencies:
-    babel-plugin-check-es2015-constants "7.0.0-alpha.7"
-    babel-plugin-syntax-trailing-function-commas "7.0.0-alpha.7"
-    babel-plugin-transform-async-to-generator "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-arrow-functions "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-block-scoped-functions "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-block-scoping "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-classes "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-computed-properties "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-destructuring "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-duplicate-keys "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-for-of "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-function-name "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-literals "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-modules-amd "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-modules-commonjs "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-modules-systemjs "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-modules-umd "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-object-super "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-parameters "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-shorthand-properties "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-spread "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-sticky-regex "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-template-literals "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-typeof-symbol "7.0.0-alpha.7"
-    babel-plugin-transform-es2015-unicode-regex "7.0.0-alpha.7"
-    babel-plugin-transform-exponentiation-operator "7.0.0-alpha.7"
-    babel-plugin-transform-regenerator "7.0.0-alpha.7"
+    babel-plugin-check-es2015-constants "7.0.0-alpha.8"
+    babel-plugin-syntax-trailing-function-commas "7.0.0-alpha.8"
+    babel-plugin-transform-async-to-generator "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-arrow-functions "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-block-scoped-functions "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-block-scoping "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-classes "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-computed-properties "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-destructuring "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-duplicate-keys "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-for-of "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-function-name "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-literals "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-modules-amd "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-modules-commonjs "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-modules-systemjs "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-modules-umd "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-object-super "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-parameters "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-shorthand-properties "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-spread "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-sticky-regex "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-template-literals "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-typeof-symbol "7.0.0-alpha.8"
+    babel-plugin-transform-es2015-unicode-regex "7.0.0-alpha.8"
+    babel-plugin-transform-exponentiation-operator "7.0.0-alpha.8"
+    babel-plugin-transform-regenerator "7.0.0-alpha.8"
     browserslist "^1.4.0"
     invariant "^2.2.2"
     semver "^5.3.0"
 
-babel-preset-stage-3@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-7.0.0-alpha.7.tgz#fcc57d7ec8d4f072b65f2e33e4d6977e7750faf8"
+babel-preset-stage-3@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-7.0.0-alpha.8.tgz#db791c331ee4fcb52baf1d4a4e8211ea706bfe27"
   dependencies:
-    babel-plugin-transform-async-generator-functions "7.0.0-alpha.7"
-    babel-plugin-transform-object-rest-spread "7.0.0-alpha.7"
+    babel-plugin-syntax-dynamic-import "7.0.0-alpha.3"
+    babel-plugin-transform-async-generator-functions "7.0.0-alpha.8"
+    babel-plugin-transform-object-rest-spread "7.0.0-alpha.8"
 
 babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
@@ -465,11 +466,11 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-7.0.0-alpha.7.tgz#82e26500980d1b3f14d9ebe8ae8b9325dc158392"
+babel-template@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-7.0.0-alpha.8.tgz#d3784ccbca118fa61f91be56d0fb09a75b78e8e3"
   dependencies:
-    babel-traverse "7.0.0-alpha.7"
+    babel-traverse "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
     babylon "7.0.0-beta.8"
     lodash "^4.2.0"
@@ -484,12 +485,12 @@ babel-template@^6.16.0:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@7.0.0-alpha.7:
-  version "7.0.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-7.0.0-alpha.7.tgz#61cc89061b0ad0a5f9fc6df81117fac428bc4148"
+babel-traverse@7.0.0-alpha.8:
+  version "7.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-7.0.0-alpha.8.tgz#c2a727265c9e0c36d1d64e28407bad4904e1dd3d"
   dependencies:
     babel-code-frame "7.0.0-alpha.3"
-    babel-messages "7.0.0-alpha.3"
+    babel-messages "7.0.0-alpha.8"
     babel-types "7.0.0-alpha.7"
     babylon "7.0.0-beta.8"
     debug "^2.2.0"


### PR DESCRIPTION
https://github.com/babel/babel-preset-env/releases/tag/v2.0.0-alpha.6

Also made useBuiltIns: false the default again. And what was previous `true` is `"usage"`